### PR TITLE
Add final status and end date of pipeline

### DIFF
--- a/migration-scripts/v9.sql
+++ b/migration-scripts/v9.sql
@@ -1,5 +1,5 @@
 ALTER TABLE scheduled_pipelines
-    ADD COLUMN "pipeline_status" VARCHAR(40) DEFAULT 'RUNNING' NOT NULL;
+    ADD COLUMN "pipeline_status" VARCHAR(40) DEFAULT '' NOT NULL;
 
 ALTER TABLE scheduled_pipelines
     ADD COLUMN "actual_end" TIMESTAMP;

--- a/migration-scripts/v9.sql
+++ b/migration-scripts/v9.sql
@@ -1,0 +1,5 @@
+ALTER TABLE scheduled_pipelines
+    ADD COLUMN "pipeline_status" VARCHAR(40) DEFAULT 'RUNNING' NOT NULL;
+
+ALTER TABLE scheduled_pipelines
+    ADD COLUMN "actual_end" TIMESTAMP;

--- a/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
@@ -63,7 +63,7 @@ object CleanupExistingPipelines extends StarportActivity {
     logger.info(s"Getting list of in console pipelines to delete...")
 
     // get the list of pipelines to be checked this time
-    val inConsolePipelines = db.run(ScheduledPipelines().filter(_.inConsole).result).waitForResult
+    val inConsolePipelines = db.run(ScheduledPipelines().filter(sp => sp.inConsole && sp.pipelineStatus === PipelineState.FINISHED.toString).result).waitForResult
 
     logger.info(s"Retrieved ${inConsolePipelines.size} in console pipelines.")
     metrics.register(

--- a/starport-core/src/main/scala/com/krux/starport/UpdateStatusPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/UpdateStatusPipeline.scala
@@ -1,0 +1,144 @@
+package com.krux.starport
+
+import com.codahale.metrics.MetricRegistry
+import com.krux.starport.db.record.ScheduledPipeline
+import com.krux.starport.db.table.{Pipelines, ScheduledPipelines}
+import com.krux.starport.metric.{ConstantValueGauge, MetricSettings}
+import com.krux.starport.util.{AwsDataPipeline, ErrorHandler, PipelineState}
+import slick.jdbc.PostgresProfile.api._
+
+import java.time.LocalDateTime
+
+object UpdateStatusPipeline extends StarportActivity {
+
+  val metrics = new MetricRegistry()
+
+  lazy val reportingEngine: MetricSettings = conf.metricsEngine
+
+  private def updateStatusToDeleted(awsId: String) = db
+    .run(
+      ScheduledPipelines()
+        .filter(_.awsId === awsId)
+        .map(_.pipelineStatus)
+        .update("DELETED")
+    )
+    .waitForResult
+
+  private def updateStatusToFinished(awsId: String, endTime: String) = db
+    .run(
+      ScheduledPipelines()
+        .filter(_.awsId === awsId)
+        .map(r => (r.pipelineStatus, r.actualEnd))
+        .update((PipelineState.FINISHED.toString, Option(LocalDateTime.parse(endTime))))
+    )
+    .waitForResult
+
+  private def updateStatusToFailed(awsId: String, endTime: String) = db
+    .run(
+      ScheduledPipelines()
+        .filter(_.awsId === awsId)
+        .map(r => (r.pipelineStatus, r.actualEnd))
+        .update((PipelineState.FAILED.toString, Option(LocalDateTime.parse(endTime))))
+    )
+    .waitForResult
+
+  def run(): Unit = {
+
+    val inConsoleRunningPipelines: Seq[ScheduledPipeline] = db
+      .run(
+        ScheduledPipelines()
+          .filter(sp =>
+            sp.inConsole && sp.pipelineStatus === PipelineState.RUNNING.toString && sp.scheduledStart > java.time.LocalDateTime
+              .now()
+              .minusDays(3)
+          )
+          .result
+      )
+      .waitForResult
+
+    inConsoleRunningPipelines.groupBy(_.pipelineId).par.foreach {case (pipelineId, scheduledPipelines) =>
+
+        val pipelineRecord = db.run(Pipelines().filter(_.id === pipelineId).take(1).result)
+          .waitForResult
+          .head
+
+        try {
+
+          val pipelineIdPrefix = s"|PipelineId: $pipelineId|"
+          logger.info(
+            s"$pipelineIdPrefix has ${scheduledPipelines.size} In-Console Running Pipelines in DB."
+          )
+
+          val awsManagedPipelineStatus =
+            AwsDataPipeline.describePipeline(scheduledPipelines.map(_.awsId): _*)
+
+          val awsManagedKeySet = awsManagedPipelineStatus.keySet
+          logger.info(s"$pipelineIdPrefix AWS contains ${awsManagedKeySet.size}")
+
+          val inDatabaseButNotInAws = scheduledPipelines.map(_.awsId).toSet -- awsManagedKeySet
+          logger.info(
+            if (inDatabaseButNotInAws.nonEmpty)
+              s"$pipelineIdPrefix updating the status to DELETED for ${inDatabaseButNotInAws.size} entries"
+            else ""
+          )
+
+          inDatabaseButNotInAws.foreach(updateStatusToDeleted)
+
+          //Finished does not mean successful, it will contain Failed & Successful both. Failed is Pipeline finished or no longer running but With Errors in any step.
+          val finishedPipelines = scheduledPipelines.filter { p =>
+            awsManagedPipelineStatus
+              .get(p.awsId)
+              .flatMap(_.pipelineState)
+              .contains(PipelineState.FINISHED)
+          }
+
+          logger.info(s"$pipelineIdPrefix has ${finishedPipelines.size} finished pipelines.")
+
+          val (failedPipelines, healthyPipelines) = finishedPipelines.partition { p =>
+            awsManagedPipelineStatus.get(p.awsId).flatMap(_.healthStatus).contains("ERROR")
+          }
+
+          val healthyAwsIds = healthyPipelines.map(_.awsId)
+          val healthyPipelinesDesc = awsManagedPipelineStatus
+            .filter(dataFromAWS => healthyAwsIds.contains(dataFromAWS._2.awsId))
+
+          val failedAwsIds = failedPipelines.map(_.awsId)
+          val failedPipelinesDesc = awsManagedPipelineStatus
+            .filter(dataFromAWS => failedAwsIds.contains(dataFromAWS._2.awsId))
+
+          healthyPipelinesDesc
+            .map(data => updateStatusToFinished(data._2.awsId, data._2.finishedTime.orNull))
+          failedPipelinesDesc
+            .map(data => updateStatusToFailed(data._2.awsId, data._2.finishedTime.orNull))
+
+        } catch {
+          case e: Exception => println(e.printStackTrace())
+          ErrorHandler.statusUpdateActivityFailed(pipelineRecord, e.getStackTrace)
+        }
+
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    val reporter = reportingEngine.getReporter(metrics)
+
+    val start = System.nanoTime
+    try {
+      run()
+
+      val timeSpan = (System.nanoTime - start) / 1e9
+      logger.info(s"All pipelines Status Updated in $timeSpan seconds")
+
+      val numActivePipelines = CleanupExistingPipelines.activePipelineRecords()
+
+      metrics.register(
+        "gauges.active_pipeline_count", new ConstantValueGauge(numActivePipelines)
+      )
+    } finally {
+      reporter.report()
+      reporter.close()
+    }
+  }
+
+}

--- a/starport-core/src/main/scala/com/krux/starport/db/record/ScheduledPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/record/ScheduledPipeline.scala
@@ -11,12 +11,14 @@ import java.time.LocalDateTime
 
 
 case class ScheduledPipeline(
-  awsId: String,
-  pipelineId: Int,
-  pipelineName: String,
-  scheduledStart: LocalDateTime,
-  actualStart: LocalDateTime,
-  deployedTime: LocalDateTime,
-  status: String,
-  inConsole: Boolean
-)
+                              awsId: String,
+                              pipelineId: Int,
+                              pipelineName: String,
+                              scheduledStart: LocalDateTime,
+                              actualStart: LocalDateTime,
+                              deployedTime: LocalDateTime,
+                              status: String,
+                              inConsole: Boolean,
+                              pipelineStatus: String,
+                              actualEnd: Option[LocalDateTime]
+                            )

--- a/starport-core/src/main/scala/com/krux/starport/db/table/ScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/table/ScheduledPipelines.scala
@@ -55,8 +55,19 @@ class ScheduledPipelines(tag: Tag) extends Table[ScheduledPipeline](tag, "schedu
    * If this still shows in the AWS Data Pipeline console
    */
   def inConsole = column[Boolean]("in_console")
+  /**
+   * The final pipeline status for monitoring purpose
+   */
 
-  def * = (awsId, pipelineId, pipelineName, scheduledStart, actualStart, deployedTime, status, inConsole) <>
+  def pipelineStatus = column[String]("pipeline_status", O.Default("RUNNING"), O.SqlType("VARCHAR(40)"))
+
+  /**
+   * Actual end time of the pipeline
+   */
+  def actualEnd = column[Option[LocalDateTime]]("actual_end")
+
+
+  def * = (awsId, pipelineId, pipelineName, scheduledStart, actualStart, deployedTime, status, inConsole, pipelineStatus, actualEnd) <>
     (ScheduledPipeline.tupled, ScheduledPipeline.unapply)
 
   def pipeline = foreignKey("sheduled_pipelines_pipelines_fk", pipelineId, TableQuery[Pipelines])(

--- a/starport-core/src/main/scala/com/krux/starport/db/table/ScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/table/ScheduledPipelines.scala
@@ -59,7 +59,7 @@ class ScheduledPipelines(tag: Tag) extends Table[ScheduledPipeline](tag, "schedu
    * The final pipeline status for monitoring purpose
    */
 
-  def pipelineStatus = column[String]("pipeline_status", O.Default("RUNNING"), O.SqlType("VARCHAR(40)"))
+  def pipelineStatus = column[String]("pipeline_status", O.Default(""), O.SqlType("VARCHAR(40)"))
 
   /**
    * Actual end time of the pipeline

--- a/starport-core/src/main/scala/com/krux/starport/util/DataPipelineDeploy.scala
+++ b/starport-core/src/main/scala/com/krux/starport/util/DataPipelineDeploy.scala
@@ -138,7 +138,9 @@ object DataPipelineDeploy {
               actualStart,
               currentTimeUTC().toLocalDateTime(),
               activationStatus,
-              true
+              true,
+              if(activationStatus.equalsIgnoreCase("success")) PipelineState.RUNNING.toString else PipelineState.FAILED.toString,
+              None
             )
           )
         )

--- a/starport-core/src/main/scala/com/krux/starport/util/ErrorHandler.scala
+++ b/starport-core/src/main/scala/com/krux/starport/util/ErrorHandler.scala
@@ -102,4 +102,17 @@ object ErrorHandler extends Logging with WaitForIt {
     )
   }
 
+  /**
+   * @return the SES send ID
+   */
+  def statusUpdateActivityFailed(pipeline: Pipeline, stackTrace: Array[StackTraceElement])(implicit conf: StarportSettings): String = {
+    val stackTraceMessage = stackTrace.mkString("\n")
+    logger.warn(s"Pipeline Status Update activity failed for pipeline ${pipeline.id}, because: $stackTraceMessage")
+    Notify(
+      s"[Starport Pipeline Status Update Failure] (${conf.pipelinePrefix}) Pipeline Status Update activity failed for ${pipeline.name}",
+      stackTraceMessage,
+      pipeline
+    )
+  }
+
 }

--- a/starport-core/src/main/scala/com/krux/starport/util/PipelineStatus.scala
+++ b/starport-core/src/main/scala/com/krux/starport/util/PipelineStatus.scala
@@ -12,18 +12,20 @@ import scala.collection.JavaConverters._
 import com.amazonaws.services.datapipeline.model.PipelineDescription
 
 case class PipelineStatus(
-  awsId: String,
-  name: String,
-  healthStatus: Option[String],
-  pipelineState: Option[PipelineState.State],
-  creationTime: Option[String]
-)
+                           awsId: String,
+                           name: String,
+                           healthStatus: Option[String],
+                           pipelineState: Option[PipelineState.State],
+                           creationTime: Option[String],
+                           finishedTime: Option[String]
+                         )
 
 object PipelineStatus {
 
   final val HealthStatusKey = "@healthStatus"
   final val PipelineStateKey = "@pipelineState"
   final val CreationTimeKey = "@creationTime"
+  final val LastFinishedTime = "@finishedTime"
 
   def apply(desc: PipelineDescription) = {
     val awsId = desc.getPipelineId()
@@ -36,7 +38,8 @@ object PipelineStatus {
       desc.getName,
       fields.get(HealthStatusKey),
       fields.get(PipelineStateKey).map(PipelineState.withName),
-      fields.get(CreationTimeKey)
+      fields.get(CreationTimeKey),
+      fields.get(LastFinishedTime)
     )
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.0.1"
+version in ThisBuild := "8.0.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.0.2"
+version in ThisBuild := "9.0.0"


### PR DESCRIPTION
This PR is to add new feature to capture end time and final status of a scheduled pipeline.

This has been done by adding a new activity as 'UpdateStatusPipeline'
The new flow will be StartScheduledPipelines -> UpdateStatusPipeline -> CleanupExistingPipelines.

DB changes: 2 new columns [pipeline_status, actual_end] are required to be added in table 'scheduled_pipelines'. Database changes to migrate to this version is added in repo at /migration-scripts/v9.sql 

Issue link: https://github.com/salesforce/starport/issues/4

Testing: 
The code has been tested using Salesforce DMP(Krux) dev PostgreSQL.

3 Dummy pipelines we added in pipelines table
SELECT * FROM pipelines;
<img width="1679" alt="Screenshot 2021-12-12 at 5 47 48 PM" src="https://user-images.githubusercontent.com/78475442/145711863-aaa65825-1214-413e-b791-c3d965a54801.png">

After Schedule Pipeline Execution
SELECT aws_id,pipeline_id,pipeline_status,actual_end,pipeline_name,in_console FROM scheduled_pipelines;
<img width="1679" alt="Screenshot 2021-12-12 at 5 53 51 PM" src="https://user-images.githubusercontent.com/78475442/145712038-5802f725-1f01-47aa-957a-dbb752a21f83.png">

After Update Status Pipeline execution (While one of them was still running)
<img width="1679" alt="Screenshot 2021-12-12 at 5 57 07 PM" src="https://user-images.githubusercontent.com/78475442/145712188-d79f70f6-a0c1-4e82-b5aa-9986e1655bdd.png">

After manually Deleting the running pipeline from AWS cli (aws datapipeline delete-pipeline --pipeline-id <ID>)
<img width="1679" alt="Screenshot 2021-12-12 at 6 00 31 PM" src="https://user-images.githubusercontent.com/78475442/145712299-41059316-d0f7-4082-87ff-75138f9b3d51.png">

Test for a Deactivating pipeline
<img width="1679" alt="Screenshot 2021-12-12 at 6 04 46 PM" src="https://user-images.githubusercontent.com/78475442/145712452-2924258f-30dd-48b3-b90b-1690cbb36306.png">

